### PR TITLE
Tag services with a key

### DIFF
--- a/src/ContainerBuilder.php
+++ b/src/ContainerBuilder.php
@@ -617,7 +617,13 @@ class ContainerBuilder {
                 if (!is_array($definition["tags"])) {
                     throw new ConfigException(sprintf("Error for service '%s': the tags definition was not in the expected array format", $key));
                 }
-                foreach ($definition["tags"] as $tag) {
+                foreach ($definition["tags"] as $tag => $tagKey) {
+                    // tags are either defined as ' - "#tagName" ' or ' "#tagName": "tagKey" ', so
+                    // we have to detect the type of $tag and change the variables around if required
+                    if (is_numeric($tag)) {
+                        $tag = $tagKey;
+                        $tagKey = null;
+                    }
                     $tag = self::TAG_CHAR . $tag;
                     if (!isset($container[$tag])) {
                         $container[$tag] = function() {
@@ -626,7 +632,7 @@ class ContainerBuilder {
                     }
                     /** @var TagCollection $collection */
                     $collection = $container[$tag];
-                    $collection->addService($key);
+                    $collection->addService($key, $tagKey);
                 }
             }
 

--- a/src/TagCollection.php
+++ b/src/TagCollection.php
@@ -2,19 +2,33 @@
 
 namespace Silktide\Syringe;
 
-class TagCollection 
+use Silktide\Syringe\Exception\ReferenceException;
+
+class TagCollection
 {
 
     protected $services;
 
-    public function addService($serviceName)
+    public function addService($serviceName, $key = null)
     {
-        $this->services[] = $serviceName;
+        if (!is_string($key) || empty($key)) {
+            $key = count($this->services);
+        }
+        $this->services[$key] = $serviceName;
     }
 
     public function getServices()
     {
         return $this->services;
     }
+
+    public function getService($key)
+    {
+        if (empty($this->services[$key])) {
+            throw new ReferenceException("No service with the key '$key' was found in this tag");
+        }
+        return $this->services[$key];
+    }
+
 
 } 


### PR DESCRIPTION
When defining tags for a service, allow the service to be reference by a key so we can identify it later