### PR TITLE
Private services

### DIFF
--- a/src/ContainerBuilder.php
+++ b/src/ContainerBuilder.php
@@ -607,7 +607,15 @@ class ContainerBuilder {
                 // don't alias the service here, we'll do that later when we're about to use it
                 $factory["service"] = $definition["factoryService"];
             }
-
+            
+            if (!empty($definition["private"])) {
+                // if a service is private, create a random key for it and save the reference against the actual service key 
+                $hashedName = md5($key . microtime(true));
+                
+                $this->referenceResolver->registerPrivateService($hashedName, $key);
+                $key = $hashedName;
+            }
+            
             // arguments
             $arguments = !empty($definition["arguments"])? $definition["arguments"]: [];
 

--- a/src/ReferenceResolverInterface.php
+++ b/src/ReferenceResolverInterface.php
@@ -56,4 +56,13 @@ interface ReferenceResolverInterface {
      */
     public function keyIsAliased($key);
 
+    /**
+     * Obfuscate a service name to make it private, while keeping a record to allow access to other services within
+     * the same namespace alias
+     *
+     * @param string $hashedName - the unique obfuscated service name
+     * @param string $actualName - the fully aliased service name
+     */
+    public function registerPrivateService($hashedName, $actualName);
+
 } 

--- a/test/Service/DudConsumer.php
+++ b/test/Service/DudConsumer.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Silktide\Syringe\Test\Service;
+
+/**
+ * DudConsumer
+ */
+class DudConsumer
+{
+
+    protected $dud;
+
+    public function __construct(DudService $dud)
+    {
+        $this->dud = $dud;
+    }
+
+}

--- a/test/aliased.json
+++ b/test/aliased.json
@@ -1,0 +1,14 @@
+{
+  "services": {
+    "privateService": {
+      "class": "Silktide\\Syringe\\Test\\Service\\DudService",
+      "private": true
+    },
+    "usesPrivateService": {
+      "class": "Silktide\\Syringe\\Test\\Service\\DudConsumer",
+      "arguments": [
+        "@privateService"
+      ]
+    }
+  }
+}

--- a/test/integrationTest.php
+++ b/test/integrationTest.php
@@ -7,6 +7,7 @@ $builder = new \Silktide\Syringe\ContainerBuilder($resolver, [__DIR__]);
 
 $builder->addLoader(new \Silktide\Syringe\Loader\JsonLoader());
 $builder->addConfigFile("service.json");
+$builder->addConfigFile("aliased.json", "private_test");
 
 $container = $builder->createContainer();
 
@@ -22,6 +23,16 @@ if (count($collection->services) != 1 || !$collection->services[0] instanceof \S
 $duds = $container["duds"];
 if ($duds !== $collection) {
     throw new \Exception("Aliased service did not return the same object as the original service");
+}
+
+if ($container->offsetExists("private_test.privateService")) {
+    throw new \Exception("Services marked as private are accessible from outside of their alias");
+}
+
+try {
+    $service = $container["private_test.usesPrivateService"];
+} catch (\Silktide\Syringe\Exception\ReferenceException $e) {
+    throw new \Exception("An unexpected ReferenceException was thrown when trying to access a service that uses a private service:\n" . $e->getMessage());
 }
 
 echo "\nAll tests passed\n";


### PR DESCRIPTION
Services defined with the `private` attribute are only accessible by other services in the same namespace/alias

Fixes #8