### PR TITLE
speed improvements

### DIFF
--- a/src/ContainerBuilder.php
+++ b/src/ContainerBuilder.php
@@ -142,7 +142,7 @@ class ContainerBuilder {
         $this->containerClass = $containerClass;
     }
 
-    public function setValidationEnabled(bool $enabled = true)
+    public function setValidationEnabled($enabled = true)
     {
         $this->validate = $enabled;
     }

--- a/src/ContainerBuilder.php
+++ b/src/ContainerBuilder.php
@@ -54,6 +54,17 @@ class ContainerBuilder {
     protected $containerClass = self::DEFAULT_CONTAINER_CLASS;
 
     /**
+     * It's useful to validate that your DI config is correct, but it does mean that for larger DI configs, it has to fire
+     * class_exists and method_exists for *huge* amounts of classes which in turn has to run the autoloader for every
+     * class
+     *
+     * It is useful to be able to disable this in some cases as it provides massive speed boosts
+     *
+     * @var bool
+     */
+    protected $validate = true;
+
+    /**
      * @var array
      */
     protected $loaders = [];
@@ -129,6 +140,11 @@ class ContainerBuilder {
         }
 
         $this->containerClass = $containerClass;
+    }
+
+    public function setValidationEnabled(bool $enabled = true)
+    {
+        $this->validate = $enabled;
     }
 
     /**
@@ -559,9 +575,12 @@ class ContainerBuilder {
                 throw new ReferenceException("Error resolving class for '$key'. " . $e->getMessage());
             }
 
-            if (!class_exists($class) && !interface_exists($class)) {
-                throw new ConfigException(sprintf("The service class '%s' does not exist", $class));
+            if ($this->validate) {
+                if (!class_exists($class) && !interface_exists($class)) {
+                    throw new ConfigException(sprintf("The service class '%s' does not exist", $class));
+                }
             }
+
 
             // factories
             $factory = [];
@@ -580,21 +599,27 @@ class ContainerBuilder {
                 } catch (ReferenceException $e) {
                     throw new ReferenceException("Error parsing factory class for '$key'. " . $e->getMessage());
                 }
-                if (!class_exists($factoryClass)) {
-                    throw new ConfigException(
-                        sprintf("The factory class '%s', for '%s', does not exist", $factoryClass, $key)
-                    );
+
+                if ($this->validate) {
+
+                    if (!class_exists($factoryClass)) {
+                        throw new ConfigException(
+                            sprintf("The factory class '%s', for '%s', does not exist", $factoryClass, $key)
+                        );
+                    }
+
+                    // make sure the method actually exists on the class
+                    if (!method_exists($factoryClass, $factory["method"])) {
+                        throw new ConfigException(
+                            sprintf(
+                                "Invalid factory definition. The method '%s' does not exist on the class '%s'",
+                                $factory["method"],
+                                $factoryClass
+                            )
+                        );
+                    }
                 }
-                // make sure the method actually exists on the class
-                if (!method_exists($factoryClass, $factory["method"])) {
-                    throw new ConfigException(
-                        sprintf(
-                            "Invalid factory definition. The method '%s' does not exist on the class '%s'",
-                            $factory["method"],
-                            $factoryClass
-                        )
-                    );
-                }
+
                 $factory["class"] = $factoryClass;
             }
 
@@ -695,9 +720,13 @@ class ContainerBuilder {
         if (empty($call["method"])) {
             throw new ConfigException(sprintf("Call '%s' for the service '%s' does not specify a method name", $i, $key));
         }
-        if (!empty($class) && !method_exists($class, $call["method"])) {
-            throw new ConfigException(sprintf("Error for service '%s': the method call '%s' does not exist for the class '%s'", $key, $call["method"], $class));
+
+        if ($this->validate) {
+            if (!empty($class) && !method_exists($class, $call["method"])) {
+                throw new ConfigException(sprintf("Error for service '%s': the method call '%s' does not exist for the class '%s'", $key, $call["method"], $class));
+            }
         }
+
 
         if (empty($call["arguments"])) {
             // if no arguments have been defined, set arguments to an empty array

--- a/src/Loader/YamlLoader.php
+++ b/src/Loader/YamlLoader.php
@@ -5,6 +5,7 @@ namespace Silktide\Syringe\Loader;
 use Silktide\Syringe\Exception\LoaderException;
 use Symfony\Component\Yaml\Exception\ParseException;
 use Symfony\Component\Yaml\Parser;
+use Symfony\Component\Yaml\Yaml;
 
 class YamlLoader implements LoaderInterface
 {
@@ -43,24 +44,18 @@ class YamlLoader implements LoaderInterface
      */
     public function loadFile($file)
     {
-        if (!file_exists($file)) {
-            throw new LoaderException("Requested YAML file '{$file}' doesn't exist");
-        }
-
-        $contents = file_get_contents($file);
-
         if ($this->useSymfony) {
             try {
-                // Apparently parser keeps references to the things it parses? As such, we want to create a new parser
-                // each time (uch)
-                $parser = new Parser();
-                return $parser->parse($contents);
+                if (!file_exists($file)) {
+                    throw new LoaderException("Requested YAML file '{$file}' doesn't exist");
+                }
+                return Yaml::parse(file_get_contents($file));
             } catch (ParseException $e) {
                 throw new LoaderException("Could not load the YAML file '{$file}': ".$e->getMessage());
             }
         }
 
-        $data = yaml_parse($contents);
+        $data = yaml_parse_file($file);
         if (!is_array($data)) {
             throw new LoaderException("Requested YAML file '{$file}' does not parse to an array");
         }


### PR DESCRIPTION
Syringe by default validates that every class and every method that it talks to exists.

This wouldn't be such an issue if it had the capability to cache after that validation, but it currently doesn't.

This means that it's forced to run a `class_exists` on every service mentioned, which means that it has to run a the autoloader for every service mentioned. This takes up about 50% of the runtime on large projects.

This PR allows us to overwrite that and decide we know better than syringe and run without explicitly checking.

It's recommended that if you use this functionality that you have an integration test that disables it.