### PR TITLE
[Bugfix] Support for empty tag collections

### DIFF
--- a/tests/integration/Examples/ExampleClass.php
+++ b/tests/integration/Examples/ExampleClass.php
@@ -7,6 +7,7 @@ namespace Silktide\Syringe\IntegrationTests\Examples;
 class ExampleClass
 {
     protected $arguments;
+    protected $values = [];
 
     public function __construct(...$arguments)
     {
@@ -21,5 +22,15 @@ class ExampleClass
     public function getArguments()
     {
         return $this->arguments;
+    }
+
+    public function setValue(string $key, $value)
+    {
+        $this->values[$key] = $value;
+    }
+
+    public function getValue(string $key)
+    {
+        return $this->values[$key];
     }
 }

--- a/tests/integration/Tag/EmptyTagTest.php
+++ b/tests/integration/Tag/EmptyTagTest.php
@@ -1,0 +1,55 @@
+<?php
+
+
+namespace Silktide\Syringe\IntegrationTests\Tag;
+
+
+use PHPUnit\Framework\TestCase;
+use Silktide\Syringe\IntegrationTests\Examples\ExampleClass;
+use Silktide\Syringe\IntegrationTests\Examples\TestTagInterface;
+use Silktide\Syringe\Syringe;
+use Silktide\Syringe\TagCollection;
+
+class EmptyTagTest extends TestCase
+{
+    public function testConstructorTags()
+    {
+        $container = Syringe::build([
+            "paths" => [__DIR__],
+            "files" => ["file2.yml"]
+        ]);
+
+        /**
+         * @var ExampleClass $service
+         */
+        $service = $container["my_service"];
+        self::assertInstanceOf(ExampleClass::class, $service);
+        self::assertInstanceOf(TagCollection::class, $service->getFirstArgument());
+
+        $tags = $container["#untagged"];
+        self::assertInstanceOf(TagCollection::class, $tags);
+    }
+
+
+    public function testCallableTags()
+    {
+        $container = Syringe::build([
+            "paths" => [__DIR__],
+            "files" => ["file2.yml"]
+        ]);
+
+        /**
+         * @var ExampleClass $service
+         */
+        $service = $container["my_service2"];
+        self::assertInstanceOf(ExampleClass::class, $service);
+
+        $value = $service->getValue("vegetable");
+        self::assertInstanceOf(TagCollection::class, $value);
+
+        self::assertCount(0, $value);
+
+        $tags = $container["#sweetcorn"];
+        self::assertInstanceOf(TagCollection::class, $tags);
+    }
+}

--- a/tests/integration/Tag/file2.yml
+++ b/tests/integration/Tag/file2.yml
@@ -1,0 +1,13 @@
+services:
+  my_service:
+    class: Silktide\Syringe\IntegrationTests\Examples\ExampleClass
+    arguments:
+      - "#untagged"
+
+  my_service2:
+    class: Silktide\Syringe\IntegrationTests\Examples\ExampleClass
+    calls:
+      - method: setValue
+        arguments:
+          - "vegetable"
+          - "#sweetcorn"


### PR DESCRIPTION
[Bugfix] If a TagCollection is empty, you'll get an error trying to reference it. This is inconvenient for things that are optional. This fixes it