### PR TITLE
[Feature] Add support for class omission

### DIFF
--- a/tests/integration/EmptyClass/EmptyClassTest.php
+++ b/tests/integration/EmptyClass/EmptyClassTest.php
@@ -1,0 +1,49 @@
+<?php
+
+
+namespace Silktide\Syringe\IntegrationTests\EmptyClass;
+
+
+use Cache\Adapter\PHPArray\ArrayCachePool;
+use PHPUnit\Framework\TestCase;
+use Pimple\Container;
+use Silktide\Syringe\Exception\ConfigException;
+use Silktide\Syringe\IntegrationTests\Examples\ExampleClass;
+use Silktide\Syringe\Syringe;
+
+class EmptyClassTest extends TestCase
+{
+    /**
+     * @dataProvider fileDataProvider
+     */
+    public function testEmptyClass(string $file, string $firstArg)
+    {
+        $built = Syringe::build([
+            "paths" => [__DIR__],
+            "files" => [$file]
+        ]);
+
+        /**
+         * @var ExampleClass $class
+         */
+        $class = $built->offsetGet(ExampleClass::class);
+        self::assertSame($firstArg, $class->getFirstArgument());
+    }
+
+    public function testInvalidClass()
+    {
+        self::expectException(ConfigException::class);
+        Syringe::build([
+            "paths" => [__DIR__],
+            "files" => ["file1.invalid.yml"]
+        ]);
+    }
+
+    public function fileDataProvider()
+    {
+        return [
+            ["file1.yml", "Foo"],
+            ["file2.yml", "Bar"]
+        ];
+    }
+}

--- a/tests/integration/EmptyClass/file1.invalid.yml
+++ b/tests/integration/EmptyClass/file1.invalid.yml
@@ -1,0 +1,5 @@
+services:
+  ExampleClass:
+    factoryMethod: "create"
+    arguments:
+      - "Foo"

--- a/tests/integration/EmptyClass/file1.yml
+++ b/tests/integration/EmptyClass/file1.yml
@@ -1,0 +1,4 @@
+services:
+  Silktide\Syringe\IntegrationTests\Examples\ExampleClass:
+    arguments:
+      - "Foo"

--- a/tests/integration/EmptyClass/file2.yml
+++ b/tests/integration/EmptyClass/file2.yml
@@ -1,0 +1,5 @@
+services:
+  Silktide\Syringe\IntegrationTests\Examples\ExampleClass:
+    factoryMethod: create
+    arguments:
+      - "Bar"

--- a/tests/integration/Examples/ExampleClass.php
+++ b/tests/integration/Examples/ExampleClass.php
@@ -33,4 +33,9 @@ class ExampleClass
     {
         return $this->values[$key];
     }
+
+    public static function create(...$arguments)
+    {
+        return new self(...$arguments);
+    }
 }


### PR DESCRIPTION
If you have named your service after a class, this PR allows you to omit `class:` definitions, instead pulling them directly from the serviceName.

If you use a `factoryMethod` and omit both a `factoryService` and a `factoryClass`, we now assume that you're using the same class for the factory.